### PR TITLE
Ensure the open member is initialized on exception

### DIFF
--- a/ext/gnista/gnista.c
+++ b/ext/gnista/gnista.c
@@ -90,8 +90,8 @@ static VALUE method_logwriter_initialize(VALUE self, VALUE args) {
 	}
 
 	if (returncode != SPARKEY_SUCCESS) {
-		raise_sparkey(returncode);
 		i_logwriter->open = false;
+		raise_sparkey(returncode);
 	} else {
 		i_logwriter->open = true;
 		rb_iv_set(self, "@logpath", rb_ary_entry(args, 0));
@@ -203,8 +203,8 @@ static VALUE method_logreader_initialize(VALUE self, VALUE filename) {
 	returncode = sparkey_logreader_open(&i_logreader->logreader, RSTRING_PTR(filename));
 
 	if (returncode != SPARKEY_SUCCESS) {
-		raise_sparkey(returncode);
 		i_logreader->open = false;
+		raise_sparkey(returncode);
 	} else {
 		i_logreader->open = true;
 		rb_iv_set(self, "@logpath", filename);
@@ -377,8 +377,8 @@ static VALUE method_hash_initialize(VALUE self, VALUE hash_filename, VALUE log_f
 	returncode = sparkey_hash_open(&i_hashreader->hashreader, RSTRING_PTR(hash_filename), RSTRING_PTR(log_filename));
 
 	if (returncode != SPARKEY_SUCCESS) {
-		raise_sparkey(returncode);
 		i_hashreader->open = false;
+		raise_sparkey(returncode);
 	} else {
 		i_hashreader->open = true;
 		rb_iv_set(self, "@hashpath", hash_filename);


### PR DESCRIPTION
We've observed segfaults while attempting to open non-existent stores. Although the initializer of each class correctly throws `GnistaException`, raising this error skips the initialization of the `open` member on the `instance_logwriter`, `instance_logreader` and `instance_hashreader` structs. Depending on the contents of the allocated buffer, during deallocation, the value of that member may erroneously and nondeterministically evaluate to `true`, causing a segfault in, for example, `sparkey_hash_close`. This pull request reverses the order of `raise_sparkey` and the assignment, correcting the issue in our environment.

Here's a minimal test case that reliably reproduces the issue on Mac OS X Lion (10.8.4):

``` ruby
require 'gnista'

begin
  Gnista::Hash.new(rand.to_s, rand.to_s)
rescue GnistaException
end

GC.start
# => SEGFAULT!
```

/cc @jtai @spkrka
