### PR TITLE
Fix memory leak on hash get of non-existent key

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,11 @@
+# Version 1.0.1
+
+Release date 2016-05-20
+
+### Fixed
+
+* Memory leak on hash get of non-existent key.
+
 # Version 1.0.0
 
 Release date 2014-05-28

--- a/ext/gnista/gnista.c
+++ b/ext/gnista/gnista.c
@@ -487,6 +487,7 @@ static VALUE method_hash_get(VALUE self, VALUE key) {
 	returncode = sparkey_hash_get(i_hashreader->hashreader, (uint8_t*)RSTRING_PTR(key), RSTRING_LEN(key), logiter);
 
 	if (sparkey_logiter_state(logiter) != SPARKEY_ITER_ACTIVE) {
+		sparkey_logiter_close(&logiter);
 		return Qnil;
 	}
 
@@ -494,6 +495,7 @@ static VALUE method_hash_get(VALUE self, VALUE key) {
 	uint8_t *valuebuf = malloc(wanted_valuelen);
 	uint64_t actual_valuelen;
 	returncode = sparkey_logiter_fill_value(logiter, sparkey_hash_getreader(i_hashreader->hashreader), wanted_valuelen, valuebuf, &actual_valuelen);
+	sparkey_logiter_close(&logiter);
 
 	if (returncode != SPARKEY_SUCCESS) {
 		free(valuebuf);
@@ -502,8 +504,6 @@ static VALUE method_hash_get(VALUE self, VALUE key) {
 		free(valuebuf);
 		rb_raise(GnistaException, "Corrupt entry in hash.");
 	}
-
-	sparkey_logiter_close(&logiter);
 
 	VALUE v = rb_str_new((char *)valuebuf, actual_valuelen);
 	free(valuebuf);

--- a/lib/gnista/version.rb
+++ b/lib/gnista/version.rb
@@ -1,3 +1,3 @@
 module Gnista
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
Call `sparkey_logiter_close` before returning `nil` to ensure we don't leak memory.

I took the liberty of bumping the version and updating the HISTORY as part of the pull request, hopefully that saves you a few minutes @emnl.
